### PR TITLE
Enable task persistence via localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,10 @@
                     </select>
                     <button class="add-task-btn" id="addTaskBtn">追加</button>
                 </div>
+                <div class="save-section">
+                    <button id="saveTasksBtn">保存</button>
+                    <button id="resetDefaultBtn">デフォルトに戻す</button>
+                </div>
             </div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -1,9 +1,11 @@
 // 初期タスクリスト
-let tasks = [
+const defaultTasks = [
     { name: '作業時間', duration: 25, unit: 'minutes' },
     { name: '休憩時間', duration: 5, unit: 'minutes' },
     { name: '長い休憩', duration: 15, unit: 'minutes' }
 ];
+
+let tasks = [];
 
 let timer = null;
 let timeLeft = 0;
@@ -28,6 +30,33 @@ const taskListContainer = document.getElementById('taskList');
 const container = document.querySelector('.container');
 const loopCountInput = document.getElementById('loopCount');
 const soundToggle = document.getElementById('soundToggle');
+const saveTasksBtn = document.getElementById('saveTasksBtn');
+const resetDefaultBtn = document.getElementById('resetDefaultBtn');
+
+// localStorage操作
+function loadTasks() {
+    const stored = localStorage.getItem('tasks');
+    if (stored) {
+        try {
+            tasks = JSON.parse(stored);
+        } catch (e) {
+            tasks = JSON.parse(JSON.stringify(defaultTasks));
+        }
+    } else {
+        tasks = JSON.parse(JSON.stringify(defaultTasks));
+    }
+}
+
+function saveTasks() {
+    localStorage.setItem('tasks', JSON.stringify(tasks));
+}
+
+function resetToDefault() {
+    tasks = JSON.parse(JSON.stringify(defaultTasks));
+    localStorage.removeItem('tasks');
+    resetTimer();
+    renderTaskList();
+}
 
 // 音声通知用
 const audioContext = new (window.AudioContext || window.webkitAudioContext)();
@@ -207,6 +236,7 @@ function resetTimer() {
 
 // イベントリスナーの設定
 document.addEventListener('DOMContentLoaded', () => {
+    loadTasks();
     startBtn.addEventListener('click', () => {
         const isInitialStart = startBtn.textContent === '開始';
         startTimer(isInitialStart);
@@ -290,6 +320,9 @@ document.addEventListener('DOMContentLoaded', () => {
         soundEnabled = e.target.checked;
     });
 
+    saveTasksBtn.addEventListener('click', saveTasks);
+    resetDefaultBtn.addEventListener('click', resetToDefault);
+
     // 初期化
     resetTimer();
     renderTaskList();
@@ -297,6 +330,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
-        getTaskDurationInSeconds
+        getTaskDurationInSeconds,
+        loadTasks,
+        saveTasks,
+        resetToDefault,
+        defaultTasks
     };
 }

--- a/styles.css
+++ b/styles.css
@@ -249,6 +249,13 @@ select:disabled {
     border-radius: 5px;
 }
 
+.save-section {
+    margin-top: 10px;
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+}
+
 .add-task-btn {
     padding: 8px 16px;
     font-size: 14px;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -20,6 +20,8 @@ function setupDOM() {
             <input type="number" id="newTaskDuration" value="30">
             <select id="newTaskUnit"><option value="minutes">分</option></select>
             <button id="addTaskBtn">追加</button>
+            <button id="saveTasksBtn">保存</button>
+            <button id="resetDefaultBtn">デフォルトに戻す</button>
         </div>
     `;
 }
@@ -37,6 +39,7 @@ beforeEach(() => {
 afterEach(() => {
     jest.clearAllTimers();
     document.body.innerHTML = '';
+    localStorage.clear();
 });
 
 describe('ポモドーロタイマー基本機能テスト', () => {
@@ -124,5 +127,33 @@ describe('タイマー時間計算テスト', () => {
         const task = { duration: 30, unit: 'seconds' };
         const { getTaskDurationInSeconds } = require('../script.js');
         expect(getTaskDurationInSeconds(task)).toBe(30);
+    });
+});
+
+describe('タスク保存機能テスト', () => {
+    test('タスク保存後に再読み込みしても保持される', () => {
+        document.getElementById('newTaskName').value = '保存タスク';
+        document.getElementById('addTaskBtn').click();
+        document.getElementById('saveTasksBtn').click();
+
+        jest.resetModules();
+        setupDOM();
+        require('../script.js');
+        const event = new Event('DOMContentLoaded');
+        document.dispatchEvent(event);
+        jest.runOnlyPendingTimers();
+
+        expect(document.querySelectorAll('#taskList .task-item').length).toBe(4);
+    });
+
+    test('デフォルトに戻すとlocalStorageがクリアされる', () => {
+        document.getElementById('newTaskName').value = '一時タスク';
+        document.getElementById('addTaskBtn').click();
+        document.getElementById('saveTasksBtn').click();
+
+        document.getElementById('resetDefaultBtn').click();
+
+        expect(localStorage.getItem('tasks')).toBeNull();
+        expect(document.querySelectorAll('#taskList .task-item').length).toBe(3);
     });
 });


### PR DESCRIPTION
## Summary
- add Save and Reset buttons to task settings
- persist tasks to localStorage and restore them on load
- allow reverting to default tasks and clearing storage
- update styles for new save section
- extend tests for new save/reset behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d2323110c8321a4b41187c769b03f